### PR TITLE
Track practice history in browser storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,27 @@
                         Start Practice
                     </button>
                 </div>
+
+                <div class="history-section">
+                    <div class="history-header">
+                        <h2 data-i18n="practiceHistory">Practice History</h2>
+                        <div class="history-controls">
+                            <button class="history-toggle-btn" id="historyToggleBtn" data-i18n="viewHistory">View History</button>
+                            <button class="clear-history-btn" id="clearHistoryBtn" data-i18n="clearHistory" style="display: none;">Clear History</button>
+                        </div>
+                    </div>
+                    
+                    <div class="history-content" id="historyContent" style="display: none;">
+                        <div class="overall-stats" id="overallStats">
+                            <!-- Overall statistics will be populated here -->
+                        </div>
+                        
+                        <div class="history-list" id="historyList">
+                            <div class="no-history" id="noHistory" data-i18n="noHistory">No practice sessions yet</div>
+                            <!-- History items will be populated here -->
+                        </div>
+                    </div>
+                </div>
             </div>
 
             <div class="practice-area" id="practiceArea" style="display: none;">

--- a/index.html
+++ b/index.html
@@ -31,8 +31,17 @@
 <body>
     <div class="container">
         <header id="header">
-            <h1 data-i18n="title">🏓 Table Tennis Reaction Practice</h1>
-            <p data-i18n="subtitle">Train your reflexes with random direction calls</p>
+            <div class="header-content">
+                <div class="header-text">
+                    <h1 data-i18n="title">🏓 Table Tennis Reaction Practice</h1>
+                    <p data-i18n="subtitle">Train your reflexes with random direction calls</p>
+                </div>
+                <button class="history-icon-btn" id="historyIconBtn" title="Practice History">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67V7z"/>
+                    </svg>
+                </button>
+            </div>
         </header>
 
         <main>
@@ -81,25 +90,31 @@
                         Start Practice
                     </button>
                 </div>
+            </div>
 
-                <div class="history-section">
-                    <div class="history-header">
+            <div class="history-page" id="historyPage" style="display: none;">
+                <div class="history-header">
+                    <div class="history-title-section">
+                        <button class="back-to-main-btn" id="backToMainBtn">
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/>
+                            </svg>
+                        </button>
                         <h2 data-i18n="practiceHistory">Practice History</h2>
-                        <div class="history-controls">
-                            <button class="history-toggle-btn" id="historyToggleBtn" data-i18n="viewHistory">View History</button>
-                            <button class="clear-history-btn" id="clearHistoryBtn" data-i18n="clearHistory" style="display: none;">Clear History</button>
-                        </div>
+                    </div>
+                    <div class="history-controls">
+                        <button class="clear-history-btn" id="clearHistoryBtn" data-i18n="clearHistory">Clear History</button>
+                    </div>
+                </div>
+                
+                <div class="history-content" id="historyContent">
+                    <div class="overall-stats" id="overallStats">
+                        <!-- Overall statistics will be populated here -->
                     </div>
                     
-                    <div class="history-content" id="historyContent" style="display: none;">
-                        <div class="overall-stats" id="overallStats">
-                            <!-- Overall statistics will be populated here -->
-                        </div>
-                        
-                        <div class="history-list" id="historyList">
-                            <div class="no-history" id="noHistory" data-i18n="noHistory">No practice sessions yet</div>
-                            <!-- History items will be populated here -->
-                        </div>
+                    <div class="history-list" id="historyList">
+                        <div class="no-history" id="noHistory" data-i18n="noHistory">No practice sessions yet</div>
+                        <!-- History items will be populated here -->
                     </div>
                 </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -286,7 +286,9 @@ class TableTennisReactionApp {
         this.selectionStatus = document.getElementById('selectionStatus');
         
         // History elements
-        this.historyToggleBtn = document.getElementById('historyToggleBtn');
+        this.historyIconBtn = document.getElementById('historyIconBtn');
+        this.historyPage = document.getElementById('historyPage');
+        this.backToMainBtn = document.getElementById('backToMainBtn');
         this.clearHistoryBtn = document.getElementById('clearHistoryBtn');
         this.historyContent = document.getElementById('historyContent');
         this.overallStats = document.getElementById('overallStats');
@@ -343,7 +345,8 @@ class TableTennisReactionApp {
         this.startPracticeBtn.addEventListener('click', () => this.showPracticeAreaAndStart());
 
         // History controls
-        this.historyToggleBtn.addEventListener('click', () => this.toggleHistory());
+        this.historyIconBtn.addEventListener('click', () => this.showHistoryPage());
+        this.backToMainBtn.addEventListener('click', () => this.showMainPage());
         this.clearHistoryBtn.addEventListener('click', () => this.clearHistory());
 
         // Control buttons
@@ -511,6 +514,7 @@ class TableTennisReactionApp {
     backToSelection() {
         this.stopPractice();
         this.practiceArea.style.display = 'none';
+        this.historyPage.style.display = 'none';
         this.selectionPage.style.display = 'block';
         this.header.style.display = 'block';
         this.resetStats();
@@ -934,19 +938,17 @@ class TableTennisReactionApp {
         this.statsDiv.style.display = 'none';
     }
 
-    toggleHistory() {
-        const isVisible = this.historyContent.style.display !== 'none';
-        
-        if (isVisible) {
-            this.historyContent.style.display = 'none';
-            this.historyToggleBtn.textContent = translate('viewHistory');
-            this.clearHistoryBtn.style.display = 'none';
-        } else {
-            this.updateHistoryDisplay();
-            this.historyContent.style.display = 'block';
-            this.historyToggleBtn.textContent = translate('hideHistory');
-            this.clearHistoryBtn.style.display = 'inline-block';
-        }
+    showHistoryPage() {
+        this.selectionPage.style.display = 'none';
+        this.historyPage.style.display = 'block';
+        this.header.style.display = 'none';
+        this.updateHistoryDisplay();
+    }
+
+    showMainPage() {
+        this.historyPage.style.display = 'none';
+        this.selectionPage.style.display = 'block';
+        this.header.style.display = 'block';
     }
 
     updateHistoryDisplay() {
@@ -1060,10 +1062,24 @@ document.addEventListener('keydown', (e) => {
     // Escape to go back
     if (e.code === 'Escape') {
         const practiceArea = document.getElementById('practiceArea');
+        const historyPage = document.getElementById('historyPage');
         const backBtn = document.getElementById('backBtn');
+        const backToMainBtn = document.getElementById('backToMainBtn');
         
         if (practiceArea.style.display !== 'none' && backBtn) {
             backBtn.click();
+        } else if (historyPage.style.display !== 'none' && backToMainBtn) {
+            backToMainBtn.click();
+        }
+    }
+    
+    // H key to open history from main page
+    if (e.code === 'KeyH') {
+        const selectionPage = document.getElementById('selectionPage');
+        const historyIconBtn = document.getElementById('historyIconBtn');
+        
+        if (selectionPage.style.display !== 'none' && historyIconBtn) {
+            historyIconBtn.click();
         }
     }
     

--- a/style.css
+++ b/style.css
@@ -25,6 +25,21 @@ body {
     backdrop-filter: blur(10px);
 }
 
+header {
+    position: relative;
+}
+
+.header-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+}
+
+.header-text {
+    flex: 1;
+}
+
 header h1 {
     font-size: 2.5rem;
     margin-bottom: 0.5rem;
@@ -35,6 +50,32 @@ header p {
     color: #7f8c8d;
     font-size: 1.1rem;
     margin-bottom: 2rem;
+}
+
+.history-icon-btn {
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    color: white;
+    border: none;
+    border-radius: 12px;
+    padding: 0.8rem;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    margin-top: 0.5rem;
+}
+
+.history-icon-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 16px rgba(102, 126, 234, 0.4);
+}
+
+.history-icon-btn:active {
+    transform: translateY(0);
 }
 
 .timer-selection h2 {
@@ -531,25 +572,50 @@ header p {
     margin-bottom: 1rem;
 }
 
-/* History Section Styles */
-.history-section {
-    margin-top: 2rem;
-    padding-top: 2rem;
-    border-top: 2px solid rgba(108, 117, 125, 0.2);
+/* History Page Styles */
+.history-page {
+    animation: fadeIn 0.5s ease-in;
 }
 
 .history-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 1.5rem;
+    margin-bottom: 2rem;
     flex-wrap: wrap;
     gap: 1rem;
 }
 
+.history-title-section {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.back-to-main-btn {
+    background: linear-gradient(135deg, #95a5a6, #7f8c8d);
+    color: white;
+    border: none;
+    border-radius: 10px;
+    padding: 0.8rem;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    box-shadow: 0 4px 12px rgba(149, 165, 166, 0.3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+}
+
+.back-to-main-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 16px rgba(149, 165, 166, 0.4);
+}
+
 .history-header h2 {
     color: #2c3e50;
-    font-size: 1.8rem;
+    font-size: 2rem;
     margin: 0;
 }
 
@@ -559,31 +625,22 @@ header p {
     flex-wrap: wrap;
 }
 
-.history-toggle-btn, .clear-history-btn {
-    padding: 0.6rem 1.2rem;
+.clear-history-btn {
+    padding: 0.8rem 1.5rem;
     border: none;
-    border-radius: 8px;
-    font-size: 0.9rem;
+    border-radius: 10px;
+    font-size: 1rem;
     font-weight: 600;
     cursor: pointer;
     transition: all 0.3s ease;
-}
-
-.history-toggle-btn {
-    background: linear-gradient(135deg, #667eea, #764ba2);
-    color: white;
-    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
-}
-
-.clear-history-btn {
     background: linear-gradient(135deg, #e74c3c, #c0392b);
     color: white;
     box-shadow: 0 4px 12px rgba(231, 76, 60, 0.3);
 }
 
-.history-toggle-btn:hover, .clear-history-btn:hover {
+.clear-history-btn:hover {
     transform: translateY(-2px);
-    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 6px 16px rgba(231, 76, 60, 0.4);
 }
 
 .history-content {
@@ -592,17 +649,19 @@ header p {
 
 .overall-stats {
     background: linear-gradient(135deg, #f8f9fa, #e9ecef);
-    border-radius: 15px;
-    padding: 1.5rem;
-    margin-bottom: 1.5rem;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    border-radius: 20px;
+    padding: 2rem;
+    margin-bottom: 2rem;
+    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
+    border: 2px solid rgba(102, 126, 234, 0.1);
 }
 
 .overall-stats h3 {
     color: #2c3e50;
-    margin-bottom: 1rem;
-    font-size: 1.3rem;
+    margin-bottom: 1.5rem;
+    font-size: 1.5rem;
     text-align: center;
+    font-weight: 700;
 }
 
 .stats-grid {
@@ -633,11 +692,12 @@ header p {
 }
 
 .history-list {
-    max-height: 400px;
+    max-height: 500px;
     overflow-y: auto;
-    border-radius: 15px;
-    background: rgba(255, 255, 255, 0.5);
-    padding: 1rem;
+    border-radius: 20px;
+    background: rgba(255, 255, 255, 0.6);
+    padding: 1.5rem;
+    border: 2px solid rgba(102, 126, 234, 0.1);
 }
 
 .history-item {
@@ -1151,25 +1211,48 @@ header p {
         max-width: 300px;
     }
     
-    /* History section mobile styles */
+    /* History page mobile styles */
     .history-header {
         flex-direction: column;
         align-items: center;
         text-align: center;
         gap: 1rem;
+        margin-bottom: 1.5rem;
+    }
+    
+    .history-title-section {
+        gap: 0.8rem;
     }
     
     .history-header h2 {
         font-size: 1.6rem;
     }
     
+    .back-to-main-btn {
+        width: 40px;
+        height: 40px;
+        padding: 0.6rem;
+    }
+    
     .history-controls {
         justify-content: center;
     }
     
-    .history-toggle-btn, .clear-history-btn {
+    .clear-history-btn {
         padding: 0.8rem 1.5rem;
         font-size: 0.9rem;
+    }
+    
+    .header-content {
+        flex-direction: column;
+        align-items: center;
+        gap: 1rem;
+    }
+    
+    .history-icon-btn {
+        width: 44px;
+        height: 44px;
+        margin-top: 0;
     }
     
     .stats-grid {
@@ -1316,14 +1399,37 @@ header p {
         margin-top: 0.3rem;
     }
     
-    /* History section for iPhone 14/15 Pro */
+    /* History page for iPhone 14/15 Pro */
+    .history-header {
+        margin-bottom: 1.2rem;
+    }
+    
     .history-header h2 {
         font-size: 1.4rem;
     }
     
-    .history-toggle-btn, .clear-history-btn {
+    .back-to-main-btn {
+        width: 36px;
+        height: 36px;
+        padding: 0.5rem;
+    }
+    
+    .clear-history-btn {
         padding: 0.7rem 1.2rem;
         font-size: 0.85rem;
+    }
+    
+    .header-content {
+        flex-direction: column;
+        align-items: center;
+        gap: 0.8rem;
+    }
+    
+    .history-icon-btn {
+        width: 40px;
+        height: 40px;
+        padding: 0.6rem;
+        margin-top: 0;
     }
     
     .stats-grid {

--- a/style.css
+++ b/style.css
@@ -531,6 +531,192 @@ header p {
     margin-bottom: 1rem;
 }
 
+/* History Section Styles */
+.history-section {
+    margin-top: 2rem;
+    padding-top: 2rem;
+    border-top: 2px solid rgba(108, 117, 125, 0.2);
+}
+
+.history-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.history-header h2 {
+    color: #2c3e50;
+    font-size: 1.8rem;
+    margin: 0;
+}
+
+.history-controls {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.history-toggle-btn, .clear-history-btn {
+    padding: 0.6rem 1.2rem;
+    border: none;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.history-toggle-btn {
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    color: white;
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
+}
+
+.clear-history-btn {
+    background: linear-gradient(135deg, #e74c3c, #c0392b);
+    color: white;
+    box-shadow: 0 4px 12px rgba(231, 76, 60, 0.3);
+}
+
+.history-toggle-btn:hover, .clear-history-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+}
+
+.history-content {
+    animation: fadeIn 0.3s ease-in;
+}
+
+.overall-stats {
+    background: linear-gradient(135deg, #f8f9fa, #e9ecef);
+    border-radius: 15px;
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.overall-stats h3 {
+    color: #2c3e50;
+    margin-bottom: 1rem;
+    font-size: 1.3rem;
+    text-align: center;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+}
+
+.stat-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.8rem;
+    background: rgba(255, 255, 255, 0.7);
+    border-radius: 10px;
+    border-left: 4px solid #667eea;
+}
+
+.stat-label {
+    color: #7f8c8d;
+    font-size: 0.9rem;
+}
+
+.stat-value {
+    color: #2c3e50;
+    font-weight: 700;
+    font-size: 1rem;
+}
+
+.history-list {
+    max-height: 400px;
+    overflow-y: auto;
+    border-radius: 15px;
+    background: rgba(255, 255, 255, 0.5);
+    padding: 1rem;
+}
+
+.history-item {
+    background: rgba(255, 255, 255, 0.9);
+    border-radius: 12px;
+    padding: 1rem;
+    margin-bottom: 1rem;
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1);
+    border-left: 4px solid #667eea;
+    transition: all 0.3s ease;
+}
+
+.history-item:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.15);
+}
+
+.history-item:last-child {
+    margin-bottom: 0;
+}
+
+.history-item-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.8rem;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.history-date {
+    color: #2c3e50;
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+.history-mode {
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    color: white;
+    padding: 0.3rem 0.8rem;
+    border-radius: 20px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: capitalize;
+}
+
+.history-item-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 0.8rem;
+}
+
+.history-stat {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+
+.history-stat-label {
+    color: #7f8c8d;
+    font-size: 0.8rem;
+    margin-bottom: 0.2rem;
+}
+
+.history-stat-value {
+    color: #2c3e50;
+    font-weight: 700;
+    font-size: 0.9rem;
+}
+
+.no-history {
+    text-align: center;
+    color: #7f8c8d;
+    font-style: italic;
+    padding: 2rem;
+    font-size: 1.1rem;
+}
+
 
 
 .mode-btn.selected {
@@ -965,6 +1151,41 @@ header p {
         max-width: 300px;
     }
     
+    /* History section mobile styles */
+    .history-header {
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        gap: 1rem;
+    }
+    
+    .history-header h2 {
+        font-size: 1.6rem;
+    }
+    
+    .history-controls {
+        justify-content: center;
+    }
+    
+    .history-toggle-btn, .clear-history-btn {
+        padding: 0.8rem 1.5rem;
+        font-size: 0.9rem;
+    }
+    
+    .stats-grid {
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        gap: 0.8rem;
+    }
+    
+    .stat-item {
+        padding: 0.6rem;
+    }
+    
+    .history-item-stats {
+        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+        gap: 0.6rem;
+    }
+    
     /* Advanced layout for standard mobile */
     .advanced-layout {
         gap: 1.5rem;
@@ -1093,6 +1314,50 @@ header p {
     .selection-status {
         font-size: 0.9rem;
         margin-top: 0.3rem;
+    }
+    
+    /* History section for iPhone 14/15 Pro */
+    .history-header h2 {
+        font-size: 1.4rem;
+    }
+    
+    .history-toggle-btn, .clear-history-btn {
+        padding: 0.7rem 1.2rem;
+        font-size: 0.85rem;
+    }
+    
+    .stats-grid {
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 0.6rem;
+    }
+    
+    .stat-item {
+        padding: 0.5rem;
+    }
+    
+    .stat-label {
+        font-size: 0.8rem;
+    }
+    
+    .stat-value {
+        font-size: 0.9rem;
+    }
+    
+    .history-item {
+        padding: 0.8rem;
+    }
+    
+    .history-item-stats {
+        grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+        gap: 0.5rem;
+    }
+    
+    .history-stat-label {
+        font-size: 0.7rem;
+    }
+    
+    .history-stat-value {
+        font-size: 0.8rem;
     }
     
     /* Advanced layout for iPhone 14/15 Pro */


### PR DESCRIPTION
Add a practice history tracking feature to allow users to view past practice sessions and overall statistics, stored locally in the browser.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec29f30d-a687-4155-a274-1cb0d38141ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ec29f30d-a687-4155-a274-1cb0d38141ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

