### PR TITLE
Make left/right switch interval configurable with 20% jitter

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,17 @@
                     </div>
                 </div>
 
+                <div class="interval-section">
+                    <h2 data-i18n="interval">Switch Interval (ms)</h2>
+                    <div class="custom-duration">
+                        <div class="duration-controls">
+                            <button type="button" class="duration-btn decrease" id="decreaseIntervalBtn">−</button>
+                            <input type="number" id="intervalInput" min="100" max="1000" step="100" value="500" class="duration-input" readonly>
+                            <button type="button" class="duration-btn increase" id="increaseIntervalBtn">+</button>
+                        </div>
+                    </div>
+                </div>
+
                 <div class="mode-section">
                     <h2 data-i18n="mode">Practice Mode</h2>
                     <div class="mode-buttons">

--- a/script.js
+++ b/script.js
@@ -5,6 +5,7 @@ const I18N_DICTIONARY = {
 		titlePlain: 'Reaction Practice',
 		subtitle: 'Train your reflexes with random direction calls',
 		duration: 'Practice Duration',
+		interval: 'Switch Interval (ms)',
 		mode: 'Practice Mode',
 		basicMode: 'Basic Mode',
 		basicDesc: 'Left & Right only',
@@ -59,6 +60,7 @@ const I18N_DICTIONARY = {
 		titlePlain: '反应训练',
 		subtitle: '通过随机方向口令训练反应能力',
 		duration: '练习时长',
+		interval: '切换间隔 (毫秒)',
 		mode: '练习模式',
 		basicMode: '基础模式',
 		basicDesc: '仅左与右',
@@ -242,10 +244,17 @@ class PracticeHistoryManager {
     }
 }
 
+const MIN_SWITCH_INTERVAL_MS = 100;
+const MAX_SWITCH_INTERVAL_MS = 1000;
+const SWITCH_INTERVAL_STEP_MS = 100;
+const DEFAULT_SWITCH_INTERVAL_MS = 500;
+const SWITCH_INTERVAL_VARIATION = 0.2; // ±20% random variation
+
 class TableTennisReactionApp {
     constructor() {
         this.selectedTime = 60; // Default 1 minute
         this.selectedMode = 'basic'; // Default basic mode
+        this.selectedIntervalMs = DEFAULT_SWITCH_INTERVAL_MS;
         this.timeRemaining = 60;
         this.isRunning = false;
         this.isPaused = false;
@@ -282,6 +291,9 @@ class TableTennisReactionApp {
         this.durationInput = document.getElementById('durationInput');
         this.decreaseBtn = document.getElementById('decreaseBtn');
         this.increaseBtn = document.getElementById('increaseBtn');
+        this.intervalInput = document.getElementById('intervalInput');
+        this.decreaseIntervalBtn = document.getElementById('decreaseIntervalBtn');
+        this.increaseIntervalBtn = document.getElementById('increaseIntervalBtn');
 
         this.modeButtons = document.querySelectorAll('.mode-btn');
         this.startPracticeBtn = document.getElementById('startPracticeBtn');
@@ -333,7 +345,14 @@ class TableTennisReactionApp {
         this.durationInput.addEventListener('input', (e) => {
             this.selectTimer(parseFloat(e.target.value) * 60); // Convert minutes to seconds
         });
-        
+
+        // Switch interval controls
+        this.decreaseIntervalBtn.addEventListener('click', () => this.adjustInterval(-SWITCH_INTERVAL_STEP_MS));
+        this.increaseIntervalBtn.addEventListener('click', () => this.adjustInterval(SWITCH_INTERVAL_STEP_MS));
+        this.intervalInput.addEventListener('input', (e) => {
+            this.selectInterval(parseInt(e.target.value, 10));
+        });
+
         // Remove unused event listeners for elements that don't exist
 
         // Mode selection
@@ -461,7 +480,30 @@ class TableTennisReactionApp {
         this.updateTimeDisplay();
         this.updateStartButton();
     }
-    
+
+    adjustInterval(changeMs) {
+        const currentValue = parseInt(this.intervalInput.value, 10);
+        const newValue = Math.max(
+            MIN_SWITCH_INTERVAL_MS,
+            Math.min(MAX_SWITCH_INTERVAL_MS, currentValue + changeMs)
+        );
+        this.intervalInput.value = newValue;
+        this.selectInterval(newValue);
+    }
+
+    selectInterval(intervalMs) {
+        if (Number.isNaN(intervalMs)) return;
+        const clamped = Math.max(
+            MIN_SWITCH_INTERVAL_MS,
+            Math.min(MAX_SWITCH_INTERVAL_MS, intervalMs)
+        );
+        this.selectedIntervalMs = clamped;
+        if (parseInt(this.intervalInput.value, 10) !== clamped) {
+            this.intervalInput.value = clamped;
+        }
+        this.updateStartButton();
+    }
+
     // Removed unused methods that reference non-existent elements
 
     selectMode(mode) {
@@ -707,6 +749,7 @@ class TableTennisReactionApp {
             this.historyManager.saveSession({
                 mode: this.selectedMode,
                 duration: this.selectedTime,
+                switchIntervalMs: this.selectedIntervalMs,
                 actualTime: actualPracticeTime,
                 totalCalls: this.totalCalls,
                 intervals: [...this.intervals],
@@ -773,6 +816,7 @@ class TableTennisReactionApp {
             this.historyManager.saveSession({
                 mode: this.selectedMode,
                 duration: sessionDuration,
+                switchIntervalMs: this.selectedIntervalMs,
                 actualTime: actualPracticeTime,
                 totalCalls: this.totalCalls,
                 intervals: [...this.intervals],
@@ -799,10 +843,12 @@ class TableTennisReactionApp {
 
     scheduleNextDirection() {
         if (!this.isRunning) return;
-        
-        // Random interval between 1 and 1.5 seconds (1000-1500ms)
-        const randomInterval = Math.random() * 500 + 1000;
-        
+
+        // Apply ±SWITCH_INTERVAL_VARIATION around the configured interval.
+        const base = this.selectedIntervalMs;
+        const jitter = (Math.random() * 2 - 1) * SWITCH_INTERVAL_VARIATION;
+        const randomInterval = base * (1 + jitter);
+
         this.directionTimeout = setTimeout(() => {
             if (this.isRunning) {
                 this.showDirection();

--- a/style.css
+++ b/style.css
@@ -661,11 +661,11 @@ header p {
     animation: fadeIn 0.5s ease-in;
 }
 
-.duration-section, .mode-section {
+.duration-section, .interval-section, .mode-section {
     margin-bottom: 2.5rem;
 }
 
-.duration-section h2, .mode-section h2 {
+.duration-section h2, .interval-section h2, .mode-section h2 {
     color: #2c3e50;
     margin-bottom: 1.5rem;
     font-size: 1.8rem;
@@ -1359,11 +1359,11 @@ header p {
     }
     
     /* Combined selection page mobile styles */
-    .duration-section, .mode-section {
+    .duration-section, .interval-section, .mode-section {
         margin-bottom: 2rem;
     }
-    
-    .duration-section h2, .mode-section h2 {
+
+    .duration-section h2, .interval-section h2, .mode-section h2 {
         font-size: 1.6rem;
         margin-bottom: 1.2rem;
     }
@@ -1661,11 +1661,11 @@ header p {
     }
     
     /* Selection page optimizations for iPhone 14 Pro */
-    .duration-section, .mode-section {
+    .duration-section, .interval-section, .mode-section {
         margin-bottom: 1.5rem;
     }
-    
-    .duration-section h2, .mode-section h2 {
+
+    .duration-section h2, .interval-section h2, .mode-section h2 {
         font-size: 1.4rem;
         margin-bottom: 0.8rem;
     }


### PR DESCRIPTION
## Summary
- Adds a **Switch Interval** control on the selection page (100ms – 1000ms, 100ms step, default 500ms) so users can tune how fast the app calls directions.
- The direction scheduler now picks each next interval uniformly within **±20%** of the configured value (e.g. 500ms → 400–600ms), replacing the previously hard-coded 1000–1500ms range.
- The chosen interval is recorded on saved practice sessions (`switchIntervalMs`) so history reflects the setting that was used.
- Adds English / Chinese i18n strings for the new label and reuses the existing `.duration-controls` styling (mobile + iPhone 14 Pro breakpoints updated).

## Test plan
- [ ] Open `index.html` in a browser and confirm the new "Switch Interval (ms)" section appears between Practice Duration and Practice Mode.
- [ ] Verify the −/+ buttons step the value by 100ms and clamp at 100ms and 1000ms.
- [ ] Start a basic-mode practice at 500ms and observe that the visible switch cadence stays within ~400–600ms.
- [ ] Start a session at 100ms and at 1000ms and confirm both extremes work without jitter pushing values below 100ms or above 1200ms.
- [ ] Check the UI in mobile widths and iPhone 14 Pro width (≤ ~430px) — heading sizes and section spacing should match the existing Duration section.
- [ ] Switch language to `?lang=zh` and confirm the Chinese label "切换间隔 (毫秒)" renders.

https://claude.ai/code/session_017H55gy1C2JRaFfGhkoXxWq

---
_Generated by [Claude Code](https://claude.ai/code/session_017H55gy1C2JRaFfGhkoXxWq)_