### PR TITLE
Add Chinese language auto-detection and L/R box translations

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,19 +149,19 @@
                 <div class="direction-display" id="directionDisplay">
                     <!-- Basic Mode Layout -->
                     <div class="basic-layout" id="basicLayout">
-                        <div class="box left-box" id="leftBox">L</div>
-                        <div class="box right-box" id="rightBox">R</div>
+                        <div class="box left-box" id="leftBox" data-i18n="dirLeft">L</div>
+                        <div class="box right-box" id="rightBox" data-i18n="dirRight">R</div>
                     </div>
-                    
+
                     <!-- Advanced Mode Layout -->
                     <div class="advanced-layout" id="advancedLayout" style="display: none;">
                         <div class="box-row back-row">
-                            <div class="box left-forward-box" id="leftForwardBox">LF</div>
-                            <div class="box right-forward-box" id="rightForwardBox">RF</div>
+                            <div class="box left-forward-box" id="leftForwardBox" data-i18n="dirLeftForward">LF</div>
+                            <div class="box right-forward-box" id="rightForwardBox" data-i18n="dirRightForward">RF</div>
                         </div>
                         <div class="box-row front-row">
-                            <div class="box left-box" id="leftBoxAdv">L</div>
-                            <div class="box right-box" id="rightBoxAdv">R</div>
+                            <div class="box left-box" id="leftBoxAdv" data-i18n="dirLeft">L</div>
+                            <div class="box right-box" id="rightBoxAdv" data-i18n="dirRight">R</div>
                         </div>
                     </div>
                     

--- a/script.js
+++ b/script.js
@@ -9,6 +9,10 @@ const I18N_DICTIONARY = {
 		mode: 'Practice Mode',
 		basicMode: 'Basic Mode',
 		basicDesc: 'Left & Right only',
+		dirLeft: 'L',
+		dirRight: 'R',
+		dirLeftForward: 'LF',
+		dirRightForward: 'RF',
 		advancedMode: 'Advanced Mode',
 		advancedDesc: '4 directions with forward shots',
 		startPractice: 'START',
@@ -63,7 +67,11 @@ const I18N_DICTIONARY = {
 		interval: '切换间隔 (毫秒)',
 		mode: '练习模式',
 		basicMode: '基础模式',
-		basicDesc: '仅左与右',
+		basicDesc: '仅反手与正手',
+		dirLeft: '反手',
+		dirRight: '正手',
+		dirLeftForward: '反手前',
+		dirRightForward: '正手前',
 		advancedMode: '进阶模式',
 		advancedDesc: '四个方向含前球',
 		startPractice: '开始',
@@ -117,13 +125,16 @@ let CURRENT_LANG = 'en';
 function normalizeLanguage(langParam) {
 	if (!langParam) return 'en';
 	const lower = String(langParam).toLowerCase();
-	if (lower === 'zh' || lower === 'zh-cn' || lower === 'zh_hans') return 'zh';
+	if (lower.startsWith('zh')) return 'zh';
 	return 'en';
 }
 
 function detectLanguageFromUrl() {
 	const params = new URLSearchParams(window.location.search);
-	return normalizeLanguage(params.get('lang'));
+	const urlLang = params.get('lang');
+	if (urlLang) return normalizeLanguage(urlLang);
+	// Fall back to device/browser language
+	return normalizeLanguage(navigator.language || navigator.userLanguage);
 }
 
 function translate(key, vars = undefined) {


### PR DESCRIPTION
## Summary

- **Auto-detect device language**: `detectLanguageFromUrl()` now falls back to `navigator.language` when no `?lang=` URL param is present — Chinese users see Chinese UI automatically without any URL change
- **Broader zh locale matching**: `normalizeLanguage()` now matches any `zh-*` variant (zh-TW, zh-HK, zh-SG, etc.) instead of only zh/zh-CN/zh-Hans
- **Translate direction boxes**: L/R/LF/RF labels are now wired to the i18n system via `data-i18n` attributes — in Chinese they display as 反手 / 正手 / 反手前 / 正手前
- **Update basicDesc**: Chinese description for Basic Mode updated to "仅反手与正手" to match the new labels

## Test plan

- [ ] Open the app with a Chinese browser/device language (no URL params) — UI should be in Chinese, boxes show 反手/正手
- [ ] Open with `?lang=en` — UI in English, boxes show L/R
- [ ] Open with `?lang=zh` — UI in Chinese, boxes show 反手/正手
- [ ] Open with `?lang=zh-TW` — should resolve to Chinese
- [ ] Switch to Advanced Mode in Chinese — boxes should show 反手前/正手前 in the back row

https://claude.ai/code/session_01HHqRiEPkFzbAmCZBNJ4Atv

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHqRiEPkFzbAmCZBNJ4Atv)_